### PR TITLE
Mozilla Releases Security Updates for Firefox 111 and Firefox ESR 102.9 - 20230316002

### DIFF
--- a/advisories.md
+++ b/advisories.md
@@ -3,6 +3,7 @@
 #### 2023 March
 - 2023/03/16 - [Threat Actors Exploit Progress Telerik Vulnerability in U.S. Government IIS Server - 20230316004](/advisories/20230316004-Threat-Actors-Exploit-Telerik-Vulnerability-In-U.S.-Government-IIS-Server.md)
 - 2023/03/16 - [Adobe Releases Security Updates for Multiple Products - 20230316003](advisories/20230316003-Adobe-Security-Updates.md)
+- 2023/03/16 - [Mozilla Releases Security Updates for Firefox 111 and Firefox ESR 102.9 - 20230316002](advisories/20230316002-Mozilla-Releases-Security-Updates-for-Firefox-111-and-Firefox-ESR-102.9.md)
 - 2023/03/15 - [Microsoft March 2023 Security Updates - 20230316](/advisories/20230316001-Microsoft-Security-Updates-March-2023.md)
 - 2023/03/15 - [Fortinet FortiOS Path Traversal Vulnerability - 20230315004](/advisories/20230315004-Fortinet-FortiOS-Path-Traversal-Vulnerability.md)
 - 2023/03/15 - [Windows SmartScreen Security Feature Bypass Vulnerability - 20230315003](advisories/20230315003-Windows-SmartScreen-Security-Bypass-Vulnerability.md)

--- a/advisories/20230316002-Mozilla-Releases-Security-Updates-for-Firefox-111-and-Firefox-ESR-102.9.md
+++ b/advisories/20230316002-Mozilla-Releases-Security-Updates-for-Firefox-111-and-Firefox-ESR-102.9.md
@@ -1,0 +1,27 @@
+# Mozilla Releases Security Updates for Firefox 111 and Firefox ESR 102.9 - 20230316002
+
+## Overview
+Mozilla has released security updates to address vulnerabilities in Firefox 111 and Firefox ESR 102.9. An attacker could exploit some of these vulnerabilities to take control of an affected system.
+
+## What is the vulnerability?
+
+- [**CVE-2023-28159**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28159) - Fullscreen Notification could have been hidden by download popups on Android
+- [**CVE-2023-25748**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-25748) - Fullscreen Notification could have been hidden by window prompts on Android
+- [**CVE-2023-25749**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-25749) - Firefox for Android may have opened third-party apps without a prompt
+- [**CVE-2023-25750**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-25750) - Potential ServiceWorker cache leak during private browsing mode
+- [**CVE-2023-25751**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-25751) - Incorrect code generation during JIT compilation
+- [**CVE-2023-28160**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28160) - Redirect to Web Extension files may have leaked local path
+- [**CVE-2023-28164**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28164) - URL being dragged from a removed cross-origin iframe into the same tab triggered navigation
+- [**CVE-2023-28161**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28161) - One-time permissions granted to a local file were extended to other local files loaded in the same tab
+- [**CVE-2023-28162**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28162) - Invalid downcast in Worklets
+- [**CVE-2023-25752**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-25752) - Potential out-of-bounds when accessing throttled streams
+- [**CVE-2023-28163**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28163) - Windows Save As dialog resolved environment variables
+- [**CVE-2023-28176**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28176) - Memory safety bugs fixed in Firefox 111 and Firefox ESR 102.9
+- [**CVE-2023-28177**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28177) - Memory safety bugs fixed in Firefox 111
+
+## What is vulnerable? 
+The vulnerability affects the following products:
+- Firefox versions prior to 111 and Firefox ESR versions prior to 102.9
+
+## Recommendation
+The WA SOC recommends administrators apply the solutions as per vendor instructions to all affected products.


### PR DESCRIPTION
Mozilla Releases Security Updates for Firefox 111 and Firefox ESR 102.9 - 20230316002 Advisory