### PR TITLE
20230613-Adobe-Security-Updates

### DIFF
--- a/docs/advisories/20230613001-Adobe-Security-Updates.md
+++ b/docs/advisories/20230613001-Adobe-Security-Updates.md
@@ -1,0 +1,22 @@
+# Adobe Releases Security Updates for Multiple Products - 20230613001
+
+## Overview
+
+Adobe has released security updates to address multiple vulnerabilities in Adobe software. An attacker can exploit these vulnerabilities to take control of an affected system.
+
+## What is vulnerable?
+
+The vulnerability affects the following products:
+-   Experience Manager [APSB23-31](https://helpx.adobe.com/security/products/experience-manager/apsb23-31.html "Security updates available for Adobe Experience Manager | APSB23-31")
+-   Commerce [APSB23-35](https://helpx.adobe.com/security/products/magento/apsb23-35.html "Security update available for Adobe Commerce | APSB23-35")
+-   Animate [APSB23-36](https://helpx.adobe.com/security/products/animate/apsb23-36.html "Security updates available for Adobe Animate | APSB23-36")
+-   Substance 3D Designer [APSB23-39](https://helpx.adobe.com/security/products/substance3d_designer/apsb23-39.html "Security updates available for Substance 3D Designer | APSB23-39")
+
+## What has been observed?
+
+There is no evidence of exploitation affecting Western Australian Government networks at the time of publishing
+
+## Recommendation
+
+The WA SOC recommends administrators apply the solutions as per vendor instructions to all affected devices as mentioned in the links above.
+


### PR DESCRIPTION
Removed the CVE section as there would have been too many links.
Removed additional references section since there was no relevant additional info.