### PR TITLE
Update 20230615002-SEO-poisoning-Gootloader-Advisory.md

### DIFF
--- a/docs/advisories/20230615002-SEO-poisoning-Gootloader-Advisory.md
+++ b/docs/advisories/20230615002-SEO-poisoning-Gootloader-Advisory.md
@@ -22,7 +22,7 @@ let url=dynamic(["setman.es","tavernelentrepot.be","termowood.net","textfabrik.d
 Please be advised of the following observed IOCs for detection in your environment:
 
 ### FileName
-- Water corporation enterprise agreement 2018 wa (73606).zip - 76cdb2bad9582d23c1f6f4d868218d6c(MD5)
+- Water corporation enterprise agreement 2018 wa (73606).zip - N/A (MD5)
 - public sector csa agreement 2021 pay rates(18764).zip - 514affc78fccc14b67af699c898ec09a(MD5)
 - public sector csa agreement 2021 pay rates(60706).zip - af4f04edf5ec0b7555b3b70819acbfdd(MD5)
 - public sector csa agreement 2021 pay rates (32089).zip


### PR DESCRIPTION
Please approve the update:  
Removed a noisy HASH that was an empty malware zipped file stripped by defender.