### PR TITLE
DLINK Known Exploited

### DIFF
--- a/docs/advisories/20240517001-D-Link-Known-Exploited.md
+++ b/docs/advisories/20240517001-D-Link-Known-Exploited.md
@@ -1,0 +1,27 @@
+# D-Link Known Exploited Vulnerabilities - 20240517001
+
+## Overview
+
+Recently added to CISA's Known Exploited Vulnerabilities Catalog, there are two D-Link router vulnerabilities that allow access to sensitive information or configurations. Though these are several years old, they have been observed by other organisations to have been exploited recently.
+
+## What is the vulnerability?
+
+| CVE            | Severity     | CVSS | Product(s) Affected          | Summary                                                                                                            | Dated       |  CISA Published       |
+| -------------- | ------------ | ---- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------- | ----------- |
+| [**CVE-2021-40655**](https://nvd.nist.gov/vuln/detail/CVE-2021-40655) | **High**     | 7.5  | D-LINK-DIR-605 B2 versions before Firmware Version : 2.01MT | An attacker can obtain a user name and password by forging a post request to the /getcfg.php page | 24th Septermber 2021 | 16th May 2024
+| [**CVE-2014-100005**](https://nvd.nist.gov/vuln/detail/CVE-2014-100005) | **Medium** | 6.8  | D-Link DIR-600 firmware before 2.16WW and lower  | Multiple cross-site request forgery (CSRF) vulnerabilities in D-Link DIR-600 router (rev. Bx) with firmware before 2.17b02 allow remote attackers to hijack the authentication of administrators for requests that (1) create an administrator account or (2) enable remote management via a crafted configuration module to hedwig.cgi, (3) activate new configuration settings via a SETCFG,SAVE,ACTIVATE action to pigwidgeon.cgi, or (4) send a ping via a ping action to diagnostic.php.    | 1st January 2015 | 16th May 2024
+
+
+## What has been observed?
+
+There is no evidence of exploitation affecting Western Australian Government networks at the time of publishing, however it is known to have been exploited in other organisations worldwide.
+
+## Recommendation
+
+The WA SOC recommends to apply updates per vendor instructions or discontinue use of the product if updates are unavailable.
+
+## Additional Reference
+
+- [**DLink DIR-605**](https://legacy.us.dlink.com/pages/product.aspx?id=2b09e95d90ff4cb38830ecc04c89cee5)
+- [**DLink DIR-600**](https://legacy.us.dlink.com/pages/product.aspx?id=4587b63118524aec911191cc81605283)
+- [**CISA Known Exploited Catalog**](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)


### PR DESCRIPTION
D-Link known exploited vulnerabilities from latest CISA catalogue entries. CVE-2021-40655 & CVE-2014-100005.